### PR TITLE
Add enhancements analysis and mock components

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ The AI now provides:
 - **Connection Labels**: Clear request/response flow descriptions on arrows
 - **Visual Clarity**: Database ellipses, cache diamonds, and bidirectional arrows
 
+## Large Blobs Pattern
+
+The Large Blobs pattern handles massive file uploads by bypassing application servers with presigned URLs, storing metadata separately from blob storage, and serving downloads through a CDN.
+
+Example pattern output:
+
+```json
+{
+  "patterns": [
+    {
+      "id": "large-blobs",
+      "scope": "Direct-to-object storage uploads with metadata stored separately from binary blobs.",
+      "majorFunctionalRequirements": [
+        "Generate presigned upload URL",
+        "Direct client upload/download to blob storage",
+        "Metadata service persists file records & lifecycle"
+      ]
+    }
+  ]
+}
+```
+
 ## Architecture
 
 - **Frontend**: React + TypeScript + Vite

--- a/examples/presignedUrls.ts
+++ b/examples/presignedUrls.ts
@@ -1,0 +1,18 @@
+// Example Fastify stubs for presigned URL endpoints
+// POST /api/presign/upload -> { url, fields?, expiresAt }
+// GET /api/presign/download -> { url, expiresAt }
+
+// fastify.post('/api/presign/upload', async (req, reply) => {
+//   return {
+//     url: 'https://s3.example.com/upload',
+//     fields: { key: 'uploads/uuid', policy: 'base64', signature: 'sig' },
+//     expiresAt: Date.now() + 60_000
+//   }
+// })
+
+// fastify.get('/api/presign/download', async (req, reply) => {
+//   return {
+//     url: 'https://cdn.example.com/uuid',
+//     expiresAt: Date.now() + 60_000
+//   }
+// })

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@excalidraw/excalidraw": "^0.18.0",
@@ -25,6 +26,7 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.0",
-    "vite": "^7.1.0"
+    "vite": "^7.1.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/components/PromptInput.css
+++ b/src/components/PromptInput.css
@@ -37,7 +37,7 @@
 
 .generate-btn {
   background-color: #007bff;
-  color: #000000;
+  color: #ffffff;
   border: none;
   padding: 12px 24px;
   border-radius: 8px;
@@ -70,7 +70,7 @@
   height: 16px;
   margin: auto;
   border: 2px solid transparent;
-  border-top-color: #000000;
+  border-top-color: #ffffff;
   border-radius: 50%;
   animation: spin 1s linear infinite;
   right: 8px;

--- a/src/components/PromptInput.css
+++ b/src/components/PromptInput.css
@@ -117,6 +117,21 @@
   cursor: not-allowed;
 }
 
+.pattern-controls {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.pattern-badge {
+  background-color: #e7f5ff;
+  color: #1c7ed6;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 12px;
+}
+
 @media (max-width: 768px) {
   .input-group {
     flex-direction: column;

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -9,7 +9,6 @@ interface PromptInputProps {
 
 const PromptInput: React.FC<PromptInputProps> = ({ onGenerate, isLoading }) => {
   const [prompt, setPrompt] = useState('')
-  const [includeLargeBlobs, setIncludeLargeBlobs] = useState(false)
   const [detected, setDetected] = useState(false)
 
   useEffect(() => {
@@ -19,11 +18,7 @@ const PromptInput: React.FC<PromptInputProps> = ({ onGenerate, isLoading }) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (prompt.trim() && !isLoading) {
-      let finalPrompt = prompt.trim()
-      if (includeLargeBlobs) {
-        finalPrompt += ' --pattern=large-blobs'
-      }
-      onGenerate(finalPrompt)
+      onGenerate(prompt.trim())
     }
   }
 
@@ -58,15 +53,6 @@ const PromptInput: React.FC<PromptInputProps> = ({ onGenerate, isLoading }) => {
       </form>
       
       <div className="pattern-controls">
-        <label>
-          <input
-            type="checkbox"
-            checked={includeLargeBlobs}
-            onChange={(e) => setIncludeLargeBlobs(e.target.checked)}
-            disabled={isLoading}
-          />
-          Include Large Blobs pattern
-        </label>
         {detected && <span className="pattern-badge">Large Blobs detected</span>}
       </div>
 

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { selectPatterns } from '../services/patternSelector'
 import './PromptInput.css'
 
 interface PromptInputProps {
@@ -8,11 +9,21 @@ interface PromptInputProps {
 
 const PromptInput: React.FC<PromptInputProps> = ({ onGenerate, isLoading }) => {
   const [prompt, setPrompt] = useState('')
+  const [includeLargeBlobs, setIncludeLargeBlobs] = useState(false)
+  const [detected, setDetected] = useState(false)
+
+  useEffect(() => {
+    setDetected(selectPatterns(prompt).some(p => p.id === 'large-blobs'))
+  }, [prompt])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (prompt.trim() && !isLoading) {
-      onGenerate(prompt.trim())
+      let finalPrompt = prompt.trim()
+      if (includeLargeBlobs) {
+        finalPrompt += ' --pattern=large-blobs'
+      }
+      onGenerate(finalPrompt)
     }
   }
 
@@ -46,6 +57,19 @@ const PromptInput: React.FC<PromptInputProps> = ({ onGenerate, isLoading }) => {
         </div>
       </form>
       
+      <div className="pattern-controls">
+        <label>
+          <input
+            type="checkbox"
+            checked={includeLargeBlobs}
+            onChange={(e) => setIncludeLargeBlobs(e.target.checked)}
+            disabled={isLoading}
+          />
+          Include Large Blobs pattern
+        </label>
+        {detected && <span className="pattern-badge">Large Blobs detected</span>}
+      </div>
+
       <div className="example-prompts">
         <h3>Try these examples:</h3>
         <div className="examples-grid">

--- a/src/components/SystemAnalysisPanel.tsx
+++ b/src/components/SystemAnalysisPanel.tsx
@@ -6,13 +6,21 @@ interface SystemAnalysisPanelProps {
   diagramData: any | null
 }
 
-type SectionKey = 'requirements' | 'capacity' | 'apis' | 'database' | 'challenges' | 'tradeoffs'
+type SectionKey =
+  | 'requirements'
+  | 'capacity'
+  | 'apis'
+  | 'database'
+  | 'enhancements'
+  | 'challenges'
+  | 'tradeoffs'
 
 const sections = [
   { key: 'requirements' as SectionKey, label: 'Requirements', icon: '📋' },
   { key: 'capacity' as SectionKey, label: 'Capacity', icon: '📊' },
   { key: 'apis' as SectionKey, label: 'APIs', icon: '🔌' },
   { key: 'database' as SectionKey, label: 'Database', icon: '🗄️' },
+  { key: 'enhancements' as SectionKey, label: 'Enhancements', icon: '✨' },
   { key: 'challenges' as SectionKey, label: 'Challenges', icon: '⚡' },
   { key: 'tradeoffs' as SectionKey, label: 'Trade-offs', icon: '⚖️' }
 ]
@@ -477,6 +485,54 @@ export default function SystemAnalysisPanel({ diagramData }: SystemAnalysisPanel
     )
   }
 
+  const renderEnhancements = () => {
+    if (!analysis.enhancements) {
+      return <div className="section-content">No enhancement data</div>
+    }
+    const { caching, queues, search } = analysis.enhancements
+    return (
+      <div className="section-content">
+        <div className="subsection">
+          <h4>Caching</h4>
+          <p>
+            <strong>Data Cached:</strong> {caching.dataCached}
+          </p>
+          <p>
+            <strong>Key Format:</strong> {caching.keyFormat}
+          </p>
+          <p>
+            <strong>TTL:</strong> {caching.ttl}
+          </p>
+          <p>
+            <strong>Invalidation:</strong> {caching.invalidation}
+          </p>
+        </div>
+        <div className="subsection">
+          <h4>Queues</h4>
+          <p>
+            <strong>Purpose:</strong> {queues.purpose}
+          </p>
+          <p>
+            <strong>Workflow:</strong> {queues.workflow}
+          </p>
+        </div>
+        <div className="subsection">
+          <h4>Search</h4>
+          <p>
+            <strong>Engine:</strong> {search.engine}
+          </p>
+          <p>
+            <strong>Indexed Fields:</strong>{' '}
+            {search.indexedFields.join(', ')}
+          </p>
+          <p>
+            <strong>Result Caching:</strong> {search.resultCaching}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
   const renderChallenges = () => (
     <div className="section-content">
       {analysis.challenges.map((challenge, index) => (
@@ -543,6 +599,8 @@ export default function SystemAnalysisPanel({ diagramData }: SystemAnalysisPanel
         return renderApis()
       case 'database':
         return renderDatabase()
+      case 'enhancements':
+        return renderEnhancements()
       case 'challenges':
         return renderChallenges()
       case 'tradeoffs':

--- a/src/components/SystemAnalysisPanel.tsx
+++ b/src/components/SystemAnalysisPanel.tsx
@@ -495,38 +495,38 @@ export default function SystemAnalysisPanel({ diagramData }: SystemAnalysisPanel
         <div className="subsection">
           <h4>Caching</h4>
           <p>
-            <strong>Data Cached:</strong> {caching.dataCached}
+            <strong>Data Cached:</strong> {caching?.dataCached || 'N/A'}
           </p>
           <p>
-            <strong>Key Format:</strong> {caching.keyFormat}
+            <strong>Key Format:</strong> {caching?.keyFormat || 'N/A'}
           </p>
           <p>
-            <strong>TTL:</strong> {caching.ttl}
+            <strong>TTL:</strong> {caching?.ttl || 'N/A'}
           </p>
           <p>
-            <strong>Invalidation:</strong> {caching.invalidation}
+            <strong>Invalidation:</strong> {caching?.invalidation || 'N/A'}
           </p>
         </div>
         <div className="subsection">
           <h4>Queues</h4>
           <p>
-            <strong>Purpose:</strong> {queues.purpose}
+            <strong>Purpose:</strong> {queues?.purpose || 'N/A'}
           </p>
           <p>
-            <strong>Workflow:</strong> {queues.workflow}
+            <strong>Workflow:</strong> {queues?.workflow || 'N/A'}
           </p>
         </div>
         <div className="subsection">
           <h4>Search</h4>
           <p>
-            <strong>Engine:</strong> {search.engine}
+            <strong>Engine:</strong> {search?.engine || 'N/A'}
           </p>
           <p>
             <strong>Indexed Fields:</strong>{' '}
-            {search.indexedFields.join(', ')}
+            {search?.indexedFields?.join(', ') || 'N/A'}
           </p>
           <p>
-            <strong>Result Caching:</strong> {search.resultCaching}
+            <strong>Result Caching:</strong> {search?.resultCaching || 'N/A'}
           </p>
         </div>
       </div>

--- a/src/components/SystemAnalysisPanel.tsx
+++ b/src/components/SystemAnalysisPanel.tsx
@@ -12,6 +12,7 @@ type SectionKey =
   | 'apis'
   | 'database'
   | 'enhancements'
+  | 'patterns'
   | 'challenges'
   | 'tradeoffs'
 
@@ -21,6 +22,7 @@ const sections = [
   { key: 'apis' as SectionKey, label: 'APIs', icon: '🔌' },
   { key: 'database' as SectionKey, label: 'Database', icon: '🗄️' },
   { key: 'enhancements' as SectionKey, label: 'Enhancements', icon: '✨' },
+  { key: 'patterns' as SectionKey, label: 'Patterns', icon: '🧩' },
   { key: 'challenges' as SectionKey, label: 'Challenges', icon: '⚡' },
   { key: 'tradeoffs' as SectionKey, label: 'Trade-offs', icon: '⚖️' }
 ]
@@ -533,6 +535,57 @@ export default function SystemAnalysisPanel({ diagramData }: SystemAnalysisPanel
     )
   }
 
+  const renderPatterns = () => (
+    <div className="section-content">
+      {analysis.patterns?.map(pattern => (
+        <div key={pattern.id} className="subsection">
+          <h4>{pattern.name}</h4>
+          <p>{pattern.scope}</p>
+          <div className="subsection">
+            <h5>Major Functional Requirements</h5>
+            <ul>
+              {pattern.majorFunctionalRequirements.map((req, idx) => (
+                <li key={idx} className="core-requirement">{req}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="subsection">
+            <h5>Non-Functional Requirements</h5>
+            <ul>
+              {pattern.nonFunctionalRequirements.map((req, idx) => (
+                <li key={idx} className="nfr">{req}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="subsection">
+            <h5>Out of Scope</h5>
+            <ul>
+              {pattern.outOfScope.map((req, idx) => (
+                <li key={idx} className="out-of-scope">{req}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="subsection">
+            <h5>Core Entities</h5>
+            <ul>
+              {pattern.coreEntities.map((ent, idx) => (
+                <li key={idx}>{ent}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="subsection">
+            <h5>DB Schema</h5>
+            <pre>{pattern.dbSchemaMd}</pre>
+          </div>
+          <div className="subsection">
+            <h5>Rationale</h5>
+            <pre>{pattern.rationaleMd}</pre>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+
   const renderChallenges = () => (
     <div className="section-content">
       {analysis.challenges.map((challenge, index) => (
@@ -601,6 +654,8 @@ export default function SystemAnalysisPanel({ diagramData }: SystemAnalysisPanel
         return renderDatabase()
       case 'enhancements':
         return renderEnhancements()
+      case 'patterns':
+        return renderPatterns()
       case 'challenges':
         return renderChallenges()
       case 'tradeoffs':

--- a/src/diagrams/fitToContent.ts
+++ b/src/diagrams/fitToContent.ts
@@ -1,0 +1,17 @@
+export function fitToContent(scene: any) {
+  const elements = scene.elements || []
+  if (!elements.length) return scene
+  const minX = Math.min(...elements.map((e: any) => e.x))
+  const minY = Math.min(...elements.map((e: any) => e.y))
+  const maxX = Math.max(...elements.map((e: any) => e.x + (e.width || 0)))
+  const maxY = Math.max(...elements.map((e: any) => e.y + (e.height || 0)))
+  const width = maxX - minX
+  const height = maxY - minY
+  scene.appState = {
+    ...(scene.appState || {}),
+    scrollX: -minX + 50,
+    scrollY: -minY + 50,
+    zoom: Math.min(1, 800 / (width || 1), 600 / (height || 1))
+  }
+  return scene
+}

--- a/src/diagrams/largeBlobsScene.test.ts
+++ b/src/diagrams/largeBlobsScene.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { largeBlobsDiagramData } from './largeBlobsScene'
+
+describe('large blobs diagram', () => {
+  it('includes key nodes', () => {
+    const data = largeBlobsDiagramData()
+    expect(data.components.length).toMatchInlineSnapshot('9')
+    const labels = data.components.map(c => c.label)
+    expect(labels).toContain('Presign API')
+    expect(labels).toContain('Object Storage')
+    expect(labels).toContain('CDN')
+    expect(labels).toContain('Metadata/Scan Worker')
+  })
+})

--- a/src/diagrams/largeBlobsScene.ts
+++ b/src/diagrams/largeBlobsScene.ts
@@ -1,0 +1,95 @@
+import { fitToContent } from './fitToContent'
+import type { DiagramData } from '../types/diagram'
+
+export function largeBlobsDiagramData(): DiagramData {
+  return {
+    components: [
+      { id: 'client', type: 'client', label: 'Client', x: 0, y: 0 },
+      { id: 'auth', type: 'service', label: 'Auth/STS', x: 200, y: 0 },
+      { id: 'presign', type: 'service', label: 'Presign API', x: 400, y: 0 },
+      { id: 'object-storage', type: 'storage', label: 'Object Storage', x: 600, y: -100 },
+      { id: 'queue', type: 'queue', label: 'Event/Queue', x: 600, y: 100 },
+      { id: 'worker', type: 'service', label: 'Metadata/Scan Worker', x: 800, y: 100 },
+      { id: 'db', type: 'database', label: 'DB', x: 1000, y: 100 },
+      { id: 'cdn', type: 'service', label: 'CDN', x: 800, y: -100 },
+      { id: 'download-presign', type: 'service', label: 'Download Presign API', x: 400, y: -200 }
+    ],
+    connections: [
+      { from: 'client', to: 'auth' },
+      { from: 'auth', to: 'presign' },
+      { from: 'presign', to: 'object-storage' },
+      { from: 'client', to: 'object-storage' },
+      { from: 'object-storage', to: 'queue' },
+      { from: 'queue', to: 'worker' },
+      { from: 'worker', to: 'db' },
+      { from: 'client', to: 'download-presign' },
+      { from: 'download-presign', to: 'cdn' },
+      { from: 'cdn', to: 'object-storage' },
+      { from: 'client', to: 'cdn' }
+    ]
+  }
+}
+
+export function largeBlobsScene() {
+  const data = largeBlobsDiagramData()
+  const elements: any[] = []
+
+  data.components.forEach((c, idx) => {
+    elements.push({
+      id: c.id,
+      type: 'rectangle',
+      x: c.x,
+      y: c.y,
+      width: 120,
+      height: 60,
+      angle: 0,
+      strokeColor: '#000000',
+      backgroundColor: '#ffffff',
+      fillStyle: 'solid',
+      strokeWidth: 2,
+      strokeStyle: 'solid',
+      roughness: 1,
+      opacity: 100,
+      groupIds: [],
+      roundness: 0,
+      seed: idx + 1,
+      version: 1,
+      isDeleted: false,
+      text: c.label
+    })
+  })
+
+  data.connections.forEach((conn, idx) => {
+    const from = data.components.find(c => c.id === conn.from)!
+    const to = data.components.find(c => c.id === conn.to)!
+    elements.push({
+      id: `arrow-${idx}`,
+      type: 'arrow',
+      x: from.x + 120,
+      y: from.y + 30,
+      width: to.x - from.x - 120,
+      height: to.y - from.y,
+      angle: 0,
+      strokeColor: '#000000',
+      backgroundColor: 'transparent',
+      fillStyle: 'solid',
+      strokeWidth: 2,
+      strokeStyle: 'solid',
+      roughness: 1,
+      opacity: 100,
+      groupIds: [],
+      seed: 100 + idx,
+      version: 1,
+      isDeleted: false,
+      points: [
+        { x: 0, y: 0 },
+        { x: to.x - from.x - 120, y: to.y - from.y }
+      ],
+      startBinding: null,
+      endBinding: null
+    })
+  })
+
+  const scene = { type: 'excalidraw', elements, appState: {} }
+  return fitToContent(scene)
+}

--- a/src/index.css
+++ b/src/index.css
@@ -69,7 +69,6 @@ button:not(.excalidraw button):not([class*="ToolIcon"]):not([class*="Island"] bu
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -88,8 +87,5 @@ button:not(.excalidraw button):not([class*="ToolIcon"]):not([class*="Island"] bu
   }
   a:hover {
     color: #747bff;
-  }
-  button:not(.excalidraw button):not([class*="ToolIcon"]):not([class*="Island"] button) {
-    background-color: #f9f9f9;
   }
 }

--- a/src/patterns/index.ts
+++ b/src/patterns/index.ts
@@ -1,0 +1,4 @@
+import type { Pattern } from './types'
+import { largeBlobsPattern } from './large_blobs'
+
+export const patternRegistry: Pattern[] = [largeBlobsPattern]

--- a/src/patterns/large_blobs.ts
+++ b/src/patterns/large_blobs.ts
@@ -1,0 +1,54 @@
+import type { Pattern } from './types'
+import { largeBlobsDiagramData } from '../diagrams/largeBlobsScene'
+
+const dbSchema = `\
+CREATE TABLE blobs (
+  id UUID PRIMARY KEY,
+  storage_key TEXT NOT NULL,
+  bytes BIGINT NOT NULL,
+  content_type TEXT NOT NULL,
+  checksum TEXT,
+  status TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  owner_id UUID
+);
+
+CREATE TABLE upload_sessions (
+  id UUID PRIMARY KEY,
+  blob_id UUID REFERENCES blobs(id),
+  presigned_put_url TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  parts_uploaded INT DEFAULT 0,
+  status TEXT NOT NULL
+);`
+
+export const largeBlobsPattern: Pattern = {
+  id: 'large-blobs',
+  name: 'Handling Large Blobs',
+  scope: 'Direct-to-object storage uploads with metadata stored separately from binary blobs.',
+  when_to_apply: ['upload', 'video', 'image', 'file > 10MB', 'media', 'documents', 'attachments', 'binary'],
+  major_functional_requirements: [
+    'Generate presigned upload URL',
+    'Direct client upload/download to blob storage',
+    'Metadata service persists file records & lifecycle'
+  ],
+  out_of_scope: ['real-time AV processing', 'DLP', 'per-user analytics'],
+  non_functional_requirements: [
+    'Use CDN/edge for downloads; P95 download init < 150ms',
+    'Multipart/resumable uploads; idempotent finalize',
+    'Virus/malware scan async; quarantine on fail',
+    'Durability 11 9s (object store); RPO=0, immutability optional'
+  ],
+  core_entities: [
+    'Blob(id, storage_key, bytes, content_type, checksum, status, created_at, owner_id?)',
+    'UploadSession(id, blob_id, presigned_put_url, expires_at, parts_uploaded, status)'
+  ],
+  db_schema_md: dbSchema,
+  rationale_md: [
+    '- Use presigned URLs to bypass application servers',
+    '- Serve downloads via CDN',
+    '- Async malware scanning to protect users',
+    '- Metadata stored separately from blobs'
+  ].join('\n'),
+  diagram: largeBlobsDiagramData
+}

--- a/src/patterns/large_blobs.ts
+++ b/src/patterns/large_blobs.ts
@@ -50,5 +50,12 @@ export const largeBlobsPattern: Pattern = {
     '- Async malware scanning to protect users',
     '- Metadata stored separately from blobs'
   ].join('\n'),
-  diagram: largeBlobsDiagramData
+  diagram: largeBlobsDiagramData,
+  detect: (prompt: string) => {
+    const heuristics = new RegExp(
+      largeBlobsPattern.when_to_apply.join('|'),
+      'i'
+    )
+    return heuristics.test(prompt)
+  }
 }

--- a/src/patterns/types.ts
+++ b/src/patterns/types.ts
@@ -1,0 +1,15 @@
+import type { DiagramData } from '../types/diagram'
+
+export interface Pattern {
+  id: string
+  name: string
+  scope: string
+  when_to_apply: string[]
+  major_functional_requirements: string[]
+  out_of_scope: string[]
+  non_functional_requirements: string[]
+  core_entities: string[]
+  db_schema_md: string
+  rationale_md: string
+  diagram: () => DiagramData
+}

--- a/src/patterns/types.ts
+++ b/src/patterns/types.ts
@@ -12,4 +12,5 @@ export interface Pattern {
   db_schema_md: string
   rationale_md: string
   diagram: () => DiagramData
+  detect: (prompt: string) => boolean
 }

--- a/src/services/aiDiagramGenerator.ts
+++ b/src/services/aiDiagramGenerator.ts
@@ -2,7 +2,7 @@ import type { DiagramData } from '../types/diagram'
 
 const SYSTEM_PROMPT = `You are a system architecture expert. When given a system design prompt, you must respond with ONLY a valid JSON object that describes the system architecture and comprehensive analysis.
 
-Include 5-7 key architectural challenges in the analysis.
+Include 5-7 key architectural challenges in the analysis. Mention microservices, CDNs, change data capture (CDC), and sharding strategies when relevant.
 
 The JSON should have this exact structure:
 {
@@ -166,6 +166,23 @@ The JSON should have this exact structure:
             }
           ]
         }
+      }
+    },
+    "enhancements": {
+      "caching": {
+        "dataCached": "What data is cached",
+        "keyFormat": "Cache key naming convention",
+        "ttl": "Time-to-live value",
+        "invalidation": "Cache invalidation strategy"
+      },
+      "queues": {
+        "purpose": "Why queues are used",
+        "workflow": "Message processing workflow"
+      },
+      "search": {
+        "engine": "Search engine technology",
+        "indexedFields": ["Fields that are indexed"],
+        "resultCaching": "How search results are cached"
       }
     },
     "challenges": [

--- a/src/services/mockDiagramGenerator.ts
+++ b/src/services/mockDiagramGenerator.ts
@@ -1,5 +1,6 @@
 import type { DiagramData } from '../types/diagram'
 import { selectPatterns } from './patternSelector'
+import { applyPatterns } from './patternApplier'
 
 const analysisTemplates = {
   'chat-app': {
@@ -873,36 +874,5 @@ export const generateMockDiagram = async (prompt: string): Promise<DiagramData> 
     connections: template.connections.map(conn => ({ ...conn })),
     analysis: analysis
   }
-
-  patterns.forEach(p => {
-    const pDiagram = p.diagram()
-    base.components.push(...pDiagram.components)
-    base.connections.push(...pDiagram.connections)
-
-    base.analysis ||= {
-      requirements: { functional: [], nonFunctional: [], outOfScope: [] },
-      capacity: { dau: '', peakQps: '', storage: '', bandwidth: '' },
-      apis: [],
-      database: { choice: '', rationale: '' },
-      challenges: [],
-      tradeoffs: { summary: '' }
-    }
-
-    base.analysis.patterns = [
-      ...(base.analysis.patterns || []),
-      {
-        id: p.id,
-        name: p.name,
-        scope: p.scope,
-        majorFunctionalRequirements: p.major_functional_requirements.slice(0, 3),
-        outOfScope: p.out_of_scope,
-        nonFunctionalRequirements: p.non_functional_requirements,
-        coreEntities: p.core_entities,
-        dbSchemaMd: p.db_schema_md,
-        rationaleMd: p.rationale_md
-      }
-    ]
-  })
-
-  return base
+  return applyPatterns(base, patterns)
 }

--- a/src/services/patternApplier.ts
+++ b/src/services/patternApplier.ts
@@ -1,0 +1,46 @@
+import type { DiagramData } from '../types/diagram'
+import type { Pattern } from '../patterns/types'
+
+export function applyPatterns(base: DiagramData, patterns: Pattern[]): DiagramData {
+  if (!patterns.length) return base
+
+  const allFrs = patterns.flatMap(p =>
+    p.major_functional_requirements.map(fr => ({ id: p.id, fr }))
+  )
+  const included = allFrs.slice(0, 3)
+
+  patterns.forEach(p => {
+    const pDiagram = p.diagram()
+    base.components.push(...pDiagram.components)
+    base.connections.push(...pDiagram.connections)
+
+    base.analysis ||= {
+      requirements: { functional: [], nonFunctional: [], outOfScope: [] },
+      capacity: { dau: '', peakQps: '', storage: '', bandwidth: '' },
+      apis: [],
+      database: { choice: '', rationale: '' },
+      challenges: [],
+      tradeoffs: { summary: '' }
+    }
+
+    const frs = included.filter(f => f.id === p.id).map(f => f.fr)
+    const outFrs = p.major_functional_requirements.filter(fr => !frs.includes(fr))
+
+    base.analysis.patterns = [
+      ...(base.analysis.patterns || []),
+      {
+        id: p.id,
+        name: p.name,
+        scope: p.scope,
+        majorFunctionalRequirements: frs,
+        outOfScope: [...p.out_of_scope, ...outFrs],
+        nonFunctionalRequirements: p.non_functional_requirements,
+        coreEntities: p.core_entities,
+        dbSchemaMd: p.db_schema_md,
+        rationaleMd: p.rationale_md
+      }
+    ]
+  })
+
+  return base
+}

--- a/src/services/patternSelector.test.ts
+++ b/src/services/patternSelector.test.ts
@@ -1,0 +1,14 @@
+import { selectPatterns } from './patternSelector'
+import { describe, it, expect } from 'vitest'
+
+describe('pattern selection', () => {
+  it('detects large blob keywords', () => {
+    const patterns = selectPatterns('Design WhatsApp media uploads')
+    expect(patterns.some(p => p.id === 'large-blobs')).toBe(true)
+  })
+
+  it('detects large file uploads', () => {
+    const patterns = selectPatterns('Design Dropbox uploads 5GB')
+    expect(patterns.some(p => p.id === 'large-blobs')).toBe(true)
+  })
+})

--- a/src/services/patternSelector.ts
+++ b/src/services/patternSelector.ts
@@ -1,0 +1,16 @@
+import { largeBlobsPattern } from '../patterns/large_blobs'
+import type { Pattern } from '../patterns/types'
+
+const heuristics = new RegExp(largeBlobsPattern.when_to_apply.join('|'), 'i')
+
+export function selectPatterns(prompt: string): Pattern[] {
+  const patterns: Pattern[] = []
+  if (prompt.includes('--pattern=large-blobs') || heuristics.test(prompt)) {
+    patterns.push(largeBlobsPattern)
+  }
+  return patterns
+}
+
+export function stripPatternFlags(prompt: string): string {
+  return prompt.replace(/--pattern=[^\s]+/g, '').trim()
+}

--- a/src/services/patternSelector.ts
+++ b/src/services/patternSelector.ts
@@ -1,16 +1,17 @@
-import { largeBlobsPattern } from '../patterns/large_blobs'
 import type { Pattern } from '../patterns/types'
+import { patternRegistry } from '../patterns'
 
-const heuristics = new RegExp(largeBlobsPattern.when_to_apply.join('|'), 'i')
-
-export function selectPatterns(prompt: string): Pattern[] {
-  const patterns: Pattern[] = []
-  if (prompt.includes('--pattern=large-blobs') || heuristics.test(prompt)) {
-    patterns.push(largeBlobsPattern)
-  }
-  return patterns
+function extractPatternFlags(prompt: string): string[] {
+  const match = prompt.match(/--patterns?=([^\s]+)/)
+  return match ? match[1].split(',') : []
 }
 
 export function stripPatternFlags(prompt: string): string {
-  return prompt.replace(/--pattern=[^\s]+/g, '').trim()
+  return prompt.replace(/--patterns?=[^\s]+/g, '').trim()
+}
+
+export function selectPatterns(prompt: string): Pattern[] {
+  const flags = extractPatternFlags(prompt)
+  const cleaned = stripPatternFlags(prompt)
+  return patternRegistry.filter(p => flags.includes(p.id) || p.detect(cleaned))
 }

--- a/src/types/diagram.ts
+++ b/src/types/diagram.ts
@@ -34,6 +34,23 @@ export interface SystemAnalysis {
     rationale: string
     schema?: string
   }
+  enhancements: {
+    caching: {
+      dataCached: string
+      keyFormat: string
+      ttl: string
+      invalidation: string
+    }
+    queues: {
+      purpose: string
+      workflow: string
+    }
+    search: {
+      engine: string
+      indexedFields: string[]
+      resultCaching: string
+    }
+  }
   challenges: {
     title: string
     issueDetail: string

--- a/src/types/diagram.ts
+++ b/src/types/diagram.ts
@@ -51,6 +51,17 @@ export interface SystemAnalysis {
       resultCaching?: string
     }
   }
+  patterns?: {
+    id: string
+    name: string
+    scope: string
+    majorFunctionalRequirements: string[]
+    outOfScope: string[]
+    nonFunctionalRequirements: string[]
+    coreEntities: string[]
+    dbSchemaMd: string
+    rationaleMd: string
+  }[]
   challenges: {
     title: string
     issueDetail: string

--- a/src/types/diagram.ts
+++ b/src/types/diagram.ts
@@ -34,21 +34,21 @@ export interface SystemAnalysis {
     rationale: string
     schema?: string
   }
-  enhancements: {
-    caching: {
-      dataCached: string
-      keyFormat: string
-      ttl: string
-      invalidation: string
+  enhancements?: {
+    caching?: {
+      dataCached?: string
+      keyFormat?: string
+      ttl?: string
+      invalidation?: string
     }
-    queues: {
-      purpose: string
-      workflow: string
+    queues?: {
+      purpose?: string
+      workflow?: string
     }
-    search: {
-      engine: string
-      indexedFields: string[]
-      resultCaching: string
+    search?: {
+      engine?: string
+      indexedFields?: string[]
+      resultCaching?: string
     }
   }
   challenges: {


### PR DESCRIPTION
## Summary
- extend system analysis types with caching, queue, and search enhancement details
- prompt AI to include enhancement info and mention microservices, CDNs, CDC, and sharding
- show new Enhancements tab and mock components like search services and queues

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Missing React and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68969a542f808332b1cb998216fb8132